### PR TITLE
Feat/13 queue server redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,14 @@ services:
       MYSQL_CHARSET: utf8mb4
       MYSQL_ROOT_PASSWORD: password
       MYSQL_COLLATION: utf8mb4_unicode_ci
+  redis:
+    image: redis:alpine
+    command: redis-server --port 6379
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - 6379:6379
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     # platform: linux/amd64

--- a/service/queue/build.gradle
+++ b/service/queue/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'io.asyncer:r2dbc-mysql:1.2.0'
 	implementation 'io.r2dbc:r2dbc-h2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	//	kafka
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/service/queue/src/main/java/com/f4/fqs/queue/application/response/QueueBeanInfo.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/application/response/QueueBeanInfo.java
@@ -1,0 +1,8 @@
+package com.f4.fqs.queue.application.response;
+
+public record QueueBeanInfo(
+        String producerBeanName,
+        String consumerBeanName
+
+) {
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueBeanService.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueBeanService.java
@@ -1,0 +1,26 @@
+package com.f4.fqs.queue.application.service;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.queue.domain.model.QueueBean;
+import com.f4.fqs.queue.infrastructure.repository.QueueBeanRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import static com.f4.fqs.queue.presentation.exception.QueueErrorCode.QUEUE_BEAN_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class QueueBeanService {
+
+    private final QueueBeanRepository queueBeanRepository;
+
+    public Mono<String> getBeanName(Long beanId) {
+        return queueBeanRepository.findById(beanId)
+                .switchIfEmpty(Mono.error(new BusinessException(QUEUE_BEAN_NOT_FOUND)))
+                .map(QueueBean::getName);
+    }
+
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueuePackageService.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueuePackageService.java
@@ -1,0 +1,24 @@
+package com.f4.fqs.queue.application.service;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.queue.domain.model.QueuePackage;
+import com.f4.fqs.queue.infrastructure.repository.QueuePackageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import static com.f4.fqs.queue.presentation.exception.QueueErrorCode.QUEUE_PACKAGE_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class QueuePackageService {
+
+    private final QueuePackageRepository queuePackageRepository;
+
+    public Mono<QueuePackage> validateQueuePackage(Long queuePackageId) {
+        return queuePackageRepository.findById(queuePackageId)
+                .switchIfEmpty(Mono.error(new BusinessException(QUEUE_PACKAGE_NOT_FOUND)));
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueService.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueService.java
@@ -1,5 +1,6 @@
 package com.f4.fqs.queue.application.service;
 
+import com.f4.fqs.commons.domain.exception.BusinessException;
 import com.f4.fqs.queue.application.response.CreateQueueResponse;
 import com.f4.fqs.queue.domain.model.Queue;
 import com.f4.fqs.queue.infrastructure.repository.QueueRepository;
@@ -13,28 +14,39 @@ import reactor.core.publisher.Mono;
 import java.security.SecureRandom;
 import java.util.Base64;
 
+import static com.f4.fqs.queue.presentation.exception.QueueErrorCode.QUEUE_NAME_DUPLICATE;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class QueueService {
 
     private final QueueRepository queueRepository;
+    private final QueuePackageService packageService;
 
     @Transactional
-    public Mono<CreateQueueResponse> createQueue(CreateQueueRequest request) {
-        String secretKey = generateRandomString(16);
-        Queue queue = Queue.from(request, secretKey);
+    public Mono<CreateQueueResponse> createQueue(CreateQueueRequest request, Long userId) {
+        String secretKey = generateRandomString();
 
-        return queueRepository.save(queue)
-                .map(q -> new CreateQueueResponse(q.getSecretKey()))
-                .doOnError(e -> log.error("큐 저장 중 오류 발생: {}", e.getMessage()));
+        return queueRepository.existsByName(request.name())
+                .flatMap(exists -> {
+                    if (exists) {
+                        return Mono.error(new BusinessException(QUEUE_NAME_DUPLICATE));
+                    }
+
+                    return packageService.validateQueuePackage(request.queuePackageId())
+                            .flatMap(queuePackage -> {
+                                Queue queue = Queue.from(request, secretKey, userId, queuePackage.getId());
+                                return queueRepository.save(queue)
+                                        .map(q -> new CreateQueueResponse(q.getSecretKey()));
+                            });
+                });
     }
 
-
-    private String generateRandomString(int length) {
+    private String generateRandomString() {
         SecureRandom secureRandom = new SecureRandom();
-        byte[] randomBytes = new byte[length];
+        byte[] randomBytes = new byte[16];
         secureRandom.nextBytes(randomBytes);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes).substring(0, length);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes).substring(0, 16);
     }
 }

--- a/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueService.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/application/service/QueueService.java
@@ -2,11 +2,15 @@ package com.f4.fqs.queue.application.service;
 
 import com.f4.fqs.commons.domain.exception.BusinessException;
 import com.f4.fqs.queue.application.response.CreateQueueResponse;
+import com.f4.fqs.queue.application.response.QueueBeanInfo;
 import com.f4.fqs.queue.domain.model.Queue;
+import com.f4.fqs.queue.domain.model.QueuePackage;
 import com.f4.fqs.queue.infrastructure.repository.QueueRepository;
 import com.f4.fqs.queue.presentation.request.CreateQueueRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
@@ -23,6 +27,9 @@ public class QueueService {
 
     private final QueueRepository queueRepository;
     private final QueuePackageService packageService;
+    private final QueueBeanService queueBeanService;
+    private final ObjectMapper objectMapper;
+    private final ReactiveRedisTemplate<String, Object> reactiveRedisTemplate;
 
     @Transactional
     public Mono<CreateQueueResponse> createQueue(CreateQueueRequest request, Long userId) {
@@ -33,14 +40,28 @@ public class QueueService {
                     if (exists) {
                         return Mono.error(new BusinessException(QUEUE_NAME_DUPLICATE));
                     }
-
                     return packageService.validateQueuePackage(request.queuePackageId())
-                            .flatMap(queuePackage -> {
-                                Queue queue = Queue.from(request, secretKey, userId, queuePackage.getId());
-                                return queueRepository.save(queue)
-                                        .map(q -> new CreateQueueResponse(q.getSecretKey()));
-                            });
+                            .flatMap(queuePackage -> createAndSaveQueue(request, userId, secretKey, queuePackage));
                 });
+    }
+
+    private Mono<CreateQueueResponse> createAndSaveQueue(CreateQueueRequest request, Long userId, String secretKey, QueuePackage queuePackage) {
+        Queue queue = Queue.from(request, secretKey, userId, queuePackage.getId());
+        return queueRepository.save(queue)
+                .flatMap(q -> Mono.zip(
+                                queueBeanService.getBeanName(queuePackage.getProducerId()),
+                                queueBeanService.getBeanName(queuePackage.getConsumerId())
+                        )
+                        .flatMap(tuple -> saveToRedis(secretKey, tuple.getT1(), tuple.getT2())
+                                .then(Mono.just(new CreateQueueResponse(q.getSecretKey())))));
+    }
+
+    private Mono<Void> saveToRedis(String secretKey, String producerBeanName, String consumerBeanName) {
+        QueueBeanInfo queueBeanInfo = new QueueBeanInfo(producerBeanName, consumerBeanName);
+        // TODO. 종료 시간의 단위가 정해지면 TTL 설정
+        return Mono.fromCallable(() -> objectMapper.writeValueAsString(queueBeanInfo))
+                .flatMap(json -> reactiveRedisTemplate.opsForValue().set(secretKey, json))
+                .then();
     }
 
     private String generateRandomString() {

--- a/service/queue/src/main/java/com/f4/fqs/queue/domain/model/Queue.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/domain/model/Queue.java
@@ -19,6 +19,10 @@ public class Queue {
     @Id
     private Long Id;
 
+    private Long userId;
+
+    private Long queuePackageId;
+
     private String name;
 
     // TODO. 아래 3개 필드의 단위를 어떻게 가져갈지?
@@ -41,7 +45,7 @@ public class Queue {
     private LocalDateTime updatedAt;
 
     @Builder(access = AccessLevel.PROTECTED)
-    public Queue(int expirationTime, int maxMessageSize, boolean messageDuplicationAllowed, boolean messageOrderGuaranteed, int messageRetentionPeriod, String name, String secretKey) {
+    public Queue(int expirationTime, int maxMessageSize, boolean messageDuplicationAllowed, boolean messageOrderGuaranteed, int messageRetentionPeriod, String name, String secretKey, Long userId, Long queuePackageId) {
         this.expirationTime = expirationTime;
         this.maxMessageSize = maxMessageSize;
         this.messageDuplicationAllowed = messageDuplicationAllowed;
@@ -49,9 +53,11 @@ public class Queue {
         this.messageRetentionPeriod = messageRetentionPeriod;
         this.name = name;
         this.secretKey = secretKey;
+        this.userId = userId;
+        this.queuePackageId = queuePackageId;
     }
 
-    public static Queue from(CreateQueueRequest request, String secretKey) {
+    public static Queue from(CreateQueueRequest request, String secretKey, Long userId, Long queuePackageId) {
         return Queue.builder()
                 .expirationTime(request.expirationTime())
                 .maxMessageSize(request.maxMessageSize())
@@ -60,6 +66,8 @@ public class Queue {
                 .messageRetentionPeriod(request.messageRetentionPeriod())
                 .name(request.name())
                 .secretKey(secretKey)
+                .userId(userId)
+                .queuePackageId(queuePackageId)
                 .build();
     }
 }

--- a/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueueBean.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueueBean.java
@@ -13,7 +13,7 @@ public class QueueBean {
     @Id
     private Long id;
 
-    private String beanName;
+    private String name;
 
     private boolean messageOrderGuaranteed;
 
@@ -26,8 +26,8 @@ public class QueueBean {
     private LocalDateTime updatedAt;
 
     @Builder(access = AccessLevel.PROTECTED)
-    public QueueBean(String beanName, boolean messageOrderGuaranteed, boolean messageDuplicationAllowed) {
-        this.beanName = beanName;
+    public QueueBean(String name, boolean messageOrderGuaranteed, boolean messageDuplicationAllowed) {
+        this.name = name;
         this.messageOrderGuaranteed = messageOrderGuaranteed;
         this.messageDuplicationAllowed = messageDuplicationAllowed;
     }

--- a/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueueBean.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueueBean.java
@@ -1,0 +1,34 @@
+package com.f4.fqs.queue.domain.model;
+
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table("queue_bean")
+public class QueueBean {
+    @Id
+    private Long id;
+
+    private String beanName;
+
+    private boolean messageOrderGuaranteed;
+
+    private boolean messageDuplicationAllowed;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    public QueueBean(String beanName, boolean messageOrderGuaranteed, boolean messageDuplicationAllowed) {
+        this.beanName = beanName;
+        this.messageOrderGuaranteed = messageOrderGuaranteed;
+        this.messageDuplicationAllowed = messageDuplicationAllowed;
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueuePackage.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/domain/model/QueuePackage.java
@@ -1,0 +1,31 @@
+package com.f4.fqs.queue.domain.model;
+
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table("queue_package")
+public class QueuePackage {
+    @Id
+    private Long id;
+
+    private Long producerId;
+
+    private Long consumerId;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    public QueuePackage(Long producerId, Long consumerId) {
+        this.producerId = producerId;
+        this.consumerId = consumerId;
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationAspect.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationAspect.java
@@ -1,0 +1,43 @@
+package com.f4.fqs.queue.infrastructure.aop;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import static com.f4.fqs.queue.presentation.exception.QueueErrorCode.NOT_AUTHORIZATION;
+
+@Aspect
+@Component
+public class AuthorizationAspect {
+
+    @Around("@annotation(authorizationRequired) && args(.., exchange)")
+    public Object checkAuthorization(ProceedingJoinPoint joinPoint, AuthorizationRequired authorizationRequired, ServerWebExchange exchange) throws Throwable {
+        String rolesHeader = exchange.getRequest().getHeaders().getFirst("X-User-Roles");
+
+        // 권한 검증 로직
+        if (!hasRequiredRole(rolesHeader, authorizationRequired.value())) {
+            throw new BusinessException(NOT_AUTHORIZATION);
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private boolean hasRequiredRole(String rolesHeader, String[] requiredRoles) {
+        if (rolesHeader == null || rolesHeader.isEmpty()) {
+            return false;
+        }
+
+        String[] userRoles = rolesHeader.split(","); // TODO. 역할이 여러개라면 , 로 구분?
+        for (String role : requiredRoles) {
+            for (String userRole : userRoles) {
+                if (userRole.trim().equals(role)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationRequired.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationRequired.java
@@ -1,0 +1,12 @@
+package com.f4.fqs.queue.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthorizationRequired {
+    String[] value() default {};
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/config/RedisConfig.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/config/RedisConfig.java
@@ -1,0 +1,58 @@
+package com.f4.fqs.queue.infrastructure.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        reactiveRedisTemplate.opsForValue().get("1")
+                .doOnSuccess(i -> log.info("Initialize to redis connection."))
+                .doOnError((err) -> log.error("Failed to initialize redis connection: {}", err.getMessage()))
+                .subscribe();
+    }
+
+    @Override
+    public boolean supportsAsyncExecution() {
+        return ApplicationListener.super.supportsAsyncExecution();
+    }
+
+    @Bean
+    public ReactiveRedisTemplate<String, Object> reactiveRedisTemplate(ReactiveRedisConnectionFactory connectionFactory) {
+        var objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
+
+        Jackson2JsonRedisSerializer<Object> jsonSerializer = new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+
+        RedisSerializationContext<String, Object> serializationContext = RedisSerializationContext
+                .<String, Object>newSerializationContext()
+                .key(RedisSerializer.string())
+                .value(jsonSerializer)
+                .hashKey(RedisSerializer.string())
+                .hashValue(jsonSerializer)
+                .build();
+
+        return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueueBeanRepository.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueueBeanRepository.java
@@ -1,0 +1,9 @@
+package com.f4.fqs.queue.infrastructure.repository;
+
+import com.f4.fqs.queue.domain.model.QueueBean;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QueueBeanRepository extends ReactiveCrudRepository<QueueBean, Long> {
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueuePackageRepository.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueuePackageRepository.java
@@ -1,0 +1,9 @@
+package com.f4.fqs.queue.infrastructure.repository;
+
+import com.f4.fqs.queue.domain.model.QueuePackage;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QueuePackageRepository extends ReactiveCrudRepository<QueuePackage, Long> {
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueueRepository.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/infrastructure/repository/QueueRepository.java
@@ -3,7 +3,9 @@ package com.f4.fqs.queue.infrastructure.repository;
 import com.f4.fqs.queue.domain.model.Queue;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface QueueRepository extends ReactiveCrudRepository<Queue, Long> {
+    Mono<Boolean> existsByName(String name);
 }

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/controller/QueueController.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/controller/QueueController.java
@@ -23,11 +23,12 @@ public class QueueController {
 
     private final QueueService queueService;
 
-
+    @AuthorizationRequired({"ROLE_ROOT"}) // TODO. ROOT 권한의 이름으로 대체
     @PostMapping
     public Mono<ResponseEntity<ResponseBody<CreateQueueResponse>>> createQueue(
             @RequestBody @Valid CreateQueueRequest request,
-            @RequestHeader("X-User-Id") Long userId) {
+            @RequestHeader("X-User-Id") Long userId,
+            ServerWebExchange exchange) {
         return queueService.createQueue(request, userId).map(response -> ResponseEntity.ok(createSuccessResponse(response)));
     }
 

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/controller/QueueController.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/controller/QueueController.java
@@ -3,15 +3,14 @@ package com.f4.fqs.queue.presentation.controller;
 import com.f4.fqs.commons.domain.response.ResponseBody;
 import com.f4.fqs.queue.application.response.CreateQueueResponse;
 import com.f4.fqs.queue.application.service.QueueService;
+import com.f4.fqs.queue.infrastructure.aop.AuthorizationRequired;
 import com.f4.fqs.queue.presentation.request.CreateQueueRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import static com.f4.fqs.commons.domain.response.ResponseUtil.createSuccessResponse;
@@ -24,9 +23,12 @@ public class QueueController {
 
     private final QueueService queueService;
 
+
     @PostMapping
-    public Mono<ResponseEntity<ResponseBody<CreateQueueResponse>>> createQueue(@RequestBody CreateQueueRequest request) throws Exception {
-        return queueService.createQueue(request).map(response -> ResponseEntity.ok(createSuccessResponse(response)));
+    public Mono<ResponseEntity<ResponseBody<CreateQueueResponse>>> createQueue(
+            @RequestBody @Valid CreateQueueRequest request,
+            @RequestHeader("X-User-Id") Long userId) {
+        return queueService.createQueue(request, userId).map(response -> ResponseEntity.ok(createSuccessResponse(response)));
     }
 
 }

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/GlobalExceptionHandler.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.f4.fqs.queue.presentation.exception;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.commons.domain.exception.ErrorCode;
+import com.f4.fqs.commons.domain.response.FailedResponseBody;
+import com.f4.fqs.commons.domain.response.ResponseBody;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.support.WebExchangeBindException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class) // custom 에러
+    public ResponseEntity<ResponseBody<Void>> handleServiceException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(new FailedResponseBody(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(WebExchangeBindException.class) // Valid
+    public ResponseEntity<ResponseBody<Void>> handleMethodArgumentNotValidException(
+            WebExchangeBindException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        log.error("MethodArgumentNotValidException : {}", errorMessage);
+        return ResponseEntity.badRequest()
+                .body(new FailedResponseBody(QueueErrorCode.INVALID_INPUT_VALUE.getCode(), errorMessage));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseBody<Void>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage());
+        return ResponseEntity.internalServerError()
+                .body(new FailedResponseBody(
+                        QueueErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                        QueueErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/QueueErrorCode.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/QueueErrorCode.java
@@ -1,0 +1,27 @@
+package com.f4.fqs.queue.presentation.exception;
+
+import com.f4.fqs.commons.domain.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QueueErrorCode implements ErrorCode {
+    // Common
+    INVALID_INPUT_VALUE(400, "COMMON_0001", "잘못된 입력 값입니다."),
+    INTERNAL_SERVER_ERROR(500, "COMMON_002", "서버 에러입니다."),
+
+    // Security
+    NOT_AUTHORIZATION(403, "SECURITY_001", "권한이 없습니다."),
+
+    // Queue
+    QUEUE_NAME_DUPLICATE(409, "QUEUE_001", "이미 존재하는 대기열 이름입니다."),
+
+    // QueuePackage
+    QUEUE_PACKAGE_NOT_FOUND(404, "QUEUE_PACKAGE_001", "존재하지 않는 대기열 패키지 입니다."),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/QueueErrorCode.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/exception/QueueErrorCode.java
@@ -19,6 +19,9 @@ public enum QueueErrorCode implements ErrorCode {
 
     // QueuePackage
     QUEUE_PACKAGE_NOT_FOUND(404, "QUEUE_PACKAGE_001", "존재하지 않는 대기열 패키지 입니다."),
+
+    // QueueBean
+    QUEUE_BEAN_NOT_FOUND(404, "QUEUE_BEAN_001", "존재하지 않는 대기열 Bean 입니다."),
     ;
 
     private final int status;

--- a/service/queue/src/main/java/com/f4/fqs/queue/presentation/request/CreateQueueRequest.java
+++ b/service/queue/src/main/java/com/f4/fqs/queue/presentation/request/CreateQueueRequest.java
@@ -11,6 +11,7 @@ public record CreateQueueRequest(
         @NotNull int maxMessageSize,
         @NotNull int expirationTime,
         @NotNull boolean messageOrderGuaranteed,
-        @NotNull boolean messageDuplicationAllowed
+        @NotNull boolean messageDuplicationAllowed,
+        @NotNull Long queuePackageId
 ) {
 }

--- a/service/queue/src/main/resources/application.yml
+++ b/service/queue/src/main/resources/application.yml
@@ -4,6 +4,7 @@ server:
 spring:
   application:
     name: queue-service
+
   r2dbc:
     url: r2dbc:mysql://localhost:3306/queue
     username: root
@@ -11,6 +12,11 @@ spring:
     pool.enabled: true
     pool.initial-size: 10
     pool.max-size: 50
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
   sql:
     init:

--- a/service/queue/src/main/resources/data.sql
+++ b/service/queue/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+-- queue_bean 테이블에 데이터 삽입
+INSERT INTO queue_bean (bean_name, message_order_guaranteed, message_duplication_allowed)
+VALUES ('BeanA', TRUE, TRUE),
+       ('BeanB', FALSE, TRUE),
+       ('BeanC', TRUE, FALSE);
+
+-- queue_package 테이블에 데이터 삽입
+INSERT INTO queue_package (producer_id, consumer_id)
+VALUES (1, 2), -- BeanA가 BeanB에 메시지를 전송
+       (1, 3), -- BeanA가 BeanC에 메시지를 전송
+       (2, 3); -- BeanB가 BeanC에 메시지를 전송

--- a/service/queue/src/main/resources/data.sql
+++ b/service/queue/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 -- queue_bean 테이블에 데이터 삽입
-INSERT INTO queue_bean (bean_name, message_order_guaranteed, message_duplication_allowed)
+INSERT INTO queue_bean (name, message_order_guaranteed, message_duplication_allowed)
 VALUES ('BeanA', TRUE, TRUE),
        ('BeanB', FALSE, TRUE),
        ('BeanC', TRUE, FALSE);

--- a/service/queue/src/main/resources/schema.sql
+++ b/service/queue/src/main/resources/schema.sql
@@ -1,19 +1,16 @@
 -- 테이블이 존재할 경우 삭제
 DROP TABLE IF EXISTS queue;
 DROP TABLE IF EXISTS queue_package;
-DROP TABLE IF EXISTS queue_beans;
+DROP TABLE IF EXISTS queue_bean;
+
 
 -- 테이블 생성
-CREATE TABLE queue
+CREATE TABLE queue_bean
 (
     id                          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name                        VARCHAR(16)  NOT NULL,
-    message_retention_period    INT          NOT NULL,
-    max_message_size            INT          NOT NULL,
-    expiration_time             INT          NOT NULL,
-    message_order_guaranteed    BOOLEAN      NOT NULL,
-    message_duplication_allowed BOOLEAN      NOT NULL,
-    secret_key                  VARCHAR(255) NOT NULL UNIQUE,
+    bean_name                   VARCHAR(16) NOT NULL,
+    message_order_guaranteed    BOOLEAN     NOT NULL,
+    message_duplication_allowed BOOLEAN     NOT NULL,
     created_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
@@ -25,16 +22,23 @@ CREATE TABLE queue_package
     consumer_id BIGINT NOT NULL,
     created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (producer_id) REFERENCES queue_beans(id),
-    FOREIGN KEY (consumer_id) REFERENCES queue_beans(id)
+    FOREIGN KEY (producer_id) REFERENCES queue_bean (id) ON DELETE CASCADE,
+    FOREIGN KEY (consumer_id) REFERENCES queue_bean (id) ON DELETE CASCADE
 );
 
-CREATE TABLE queue_beans
+CREATE TABLE queue
 (
     id                          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    bean_name                   VARCHAR(16) NOT NULL,
-    message_order_guaranteed    BOOLEAN     NOT NULL,
-    message_duplication_allowed BOOLEAN     NOT NULL,
+    user_id                     BIGINT       NOT NULL,
+    queue_package_id            BIGINT       NOT NULL,
+    name                        VARCHAR(16)  NOT NULL UNIQUE,
+    message_retention_period    INT          NOT NULL,
+    max_message_size            INT          NOT NULL,
+    expiration_time             INT          NOT NULL,
+    message_order_guaranteed    BOOLEAN      NOT NULL,
+    message_duplication_allowed BOOLEAN      NOT NULL,
+    secret_key                  VARCHAR(255) NOT NULL UNIQUE,
     created_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    updated_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (queue_package_id) REFERENCES queue_package (id) ON DELETE CASCADE
 );

--- a/service/queue/src/main/resources/schema.sql
+++ b/service/queue/src/main/resources/schema.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS queue_bean;
 CREATE TABLE queue_bean
 (
     id                          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    bean_name                   VARCHAR(16) NOT NULL,
+    name                   VARCHAR(16) NOT NULL,
     message_order_guaranteed    BOOLEAN     NOT NULL,
     message_duplication_allowed BOOLEAN     NOT NULL,
     created_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/service/queue/src/test/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationAspectTest.java
+++ b/service/queue/src/test/java/com/f4/fqs/queue/infrastructure/aop/AuthorizationAspectTest.java
@@ -1,0 +1,88 @@
+package com.f4.fqs.queue.infrastructure.aop;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@Aspect
+class AuthorizationAspectTest {
+
+    private AuthorizationAspect authorizationAspect;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private ServerWebExchange exchange;
+
+    @Mock
+    private ServerHttpRequest request;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        authorizationAspect = new AuthorizationAspect();
+    }
+
+    @Test
+    void testCheckAuthorizationWithValidRole() throws Throwable {
+        // Mocking the behavior of ServerHttpRequest
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getHeaders()).thenReturn(HttpHeaders.readOnlyHttpHeaders(
+                new HttpHeaders() {{
+                    add("X-User-Roles", "ROLE_USER");
+                }}
+        ));
+
+        // Mocking the AuthorizationRequired annotation
+        AuthorizationRequired authorizationRequired = mock(AuthorizationRequired.class);
+        when(authorizationRequired.value()).thenReturn(new String[]{"ROLE_USER"});
+
+        // Setting up the mock for joinPoint.proceed()
+        when(joinPoint.proceed()).thenReturn("Success");
+
+        // Call the method to test
+        Object result = authorizationAspect.checkAuthorization(joinPoint, authorizationRequired, exchange);
+
+        // Verify that the proceed method was called
+        verify(joinPoint).proceed();
+
+        // Validate the result
+        assert result.equals("Success");
+    }
+
+    @Test
+    void testCheckAuthorizationWithInvalidRole() {
+        // Mocking the behavior of ServerHttpRequest
+        when(exchange.getRequest()).thenReturn(request);
+        when(request.getHeaders()).thenReturn(HttpHeaders.readOnlyHttpHeaders(
+                new HttpHeaders() {{
+                    add("X-User-Roles", "ROLE_ADMIN");
+                }}
+        ));
+
+        // Mocking the AuthorizationRequired annotation
+        AuthorizationRequired authorizationRequired = mock(AuthorizationRequired.class);
+        when(authorizationRequired.value()).thenReturn(new String[]{"ROLE_USER"});
+
+        // Call the method to test and expect an exception
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            authorizationAspect.checkAuthorization(joinPoint, authorizationRequired, exchange);
+        });
+
+        // Validate the exception message
+        assertEquals(403, exception.getErrorCode().getStatus());
+    }
+}

--- a/service/queue/src/test/java/com/f4/fqs/queue/infrastructure/repository/QueueRepositoryTest.java
+++ b/service/queue/src/test/java/com/f4/fqs/queue/infrastructure/repository/QueueRepositoryTest.java
@@ -37,7 +37,7 @@ class QueueRepositoryTest {
     void testSaveQueue() {
         // Given
         String secretKey = generateRandomString(16);
-        Queue queue = Queue.from(testRequest, secretKey);
+        Queue queue = Queue.from(testRequest, secretKey, 1L, 1L);
 
         // When
         Mono<Queue> savedQueueMono = queueRepository.save(queue);


### PR DESCRIPTION
<!-- 제목의 양식은 '[#이슈번호] 설명' 으로 구성해주세요. -->

### 👀 관련 이슈
- closed: #13 

### ✨ 작업한 내용
- Redis 설정
- queue server exception 설정
- custom annotation 을 통한 권한처리
- 스키마 수정
- 대기열 생성 로직 변경

### 🌀 PR Point
- 사용하기에 앞서 헷갈리는 부분이 있다면 리뷰 바랍니다.
- 로직상에 궁금한 점이나 피드백이 있다면 주저말고 달아주세요!

### 🍰 참고사항
- 커스텀 어노테이션을 사용하려면, `@AuthorizationRequired({"ROLE_ROOT"})` 해당 어노테이션과 함께 인자로 허가할 권한을 추가합니다. 그리고 해당 컨트롤러에서 `ServerWebExchange exchange` 인자를 추가해줍니다. 편의상 간단하게 생성한것이기에 위의 틀을 맞춰줘야 문제없이 실행됩니다.

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|커스텀 어노테이션 사용법|![image](https://github.com/user-attachments/assets/7d8ef572-7ace-4c92-b30c-13e45b57d2bf)|
|대기열 생성 성공|![image](https://github.com/user-attachments/assets/ce92b401-37dd-4f4f-bbd6-f215eb5c429b)![image](https://github.com/user-attachments/assets/94ed0009-07fb-49ef-957d-40a214941f6c)|


