### PR TITLE
Feat/21 queue manage server crud

### DIFF
--- a/service/queue_manage/build.gradle
+++ b/service/queue_manage/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'application'
+}
+
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
+dependencies {
+    implementation project(':common:domain')
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/QueueManageApplication.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/QueueManageApplication.java
@@ -1,0 +1,13 @@
+package com.f4.fqs.queue_manage;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class QueueManageApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(QueueManageApplication.class, args);
+    }
+
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/CloseQueueResponse.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/CloseQueueResponse.java
@@ -1,0 +1,9 @@
+package com.f4.fqs.queue_manage.application.response;
+
+import java.time.LocalDateTime;
+
+public record CloseQueueResponse(
+        Long queueId,
+        LocalDateTime expirationTime
+){
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/CreateQueueResponse.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/CreateQueueResponse.java
@@ -1,0 +1,7 @@
+package com.f4.fqs.queue_manage.application.response;
+
+public record CreateQueueResponse (
+        Long queueId,
+        String secreteKey
+){
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/UpdateQueueExpirationTimeResponse.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/response/UpdateQueueExpirationTimeResponse.java
@@ -1,0 +1,9 @@
+package com.f4.fqs.queue_manage.application.response;
+
+import java.time.LocalDateTime;
+
+public record UpdateQueueExpirationTimeResponse(
+        Long queueId,
+        LocalDateTime expirationTime
+){
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueInfo.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueInfo.java
@@ -1,0 +1,39 @@
+package com.f4.fqs.queue_manage.application.service;
+
+import com.f4.fqs.queue_manage.domain.model.Queue;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record QueueInfo(
+        Long id,
+        Long userId,
+        String name,
+        int messageRetentionPeriod,
+        int maxMessageSize,
+        LocalDateTime expirationTime,
+        boolean messageOrderGuaranteed,
+        boolean messageDuplicationAllowed,
+        boolean isActive,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime updatedAt
+        // secretKey 는 정책상 처음 발급시에만 제공.
+) {
+    public static QueueInfo fromQueue(Queue queue) {
+        return new QueueInfo(
+                queue.getId(),
+                queue.getUserId(),
+                queue.getName(),
+                queue.getMessageRetentionPeriod(),
+                queue.getMaxMessageSize(),
+                queue.getExpirationTime(),
+                queue.isMessageOrderGuaranteed(),
+                queue.isMessageDuplicationAllowed(),
+                queue.getIsActive(),
+                queue.getCreatedAt(),
+                queue.getUpdatedAt()
+        );
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
@@ -1,10 +1,13 @@
 package com.f4.fqs.queue_manage.application.service;
 
 import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.queue_manage.application.response.CloseQueueResponse;
 import com.f4.fqs.queue_manage.application.response.CreateQueueResponse;
+import com.f4.fqs.queue_manage.application.response.UpdateQueueExpirationTimeResponse;
 import com.f4.fqs.queue_manage.domain.model.Queue;
 import com.f4.fqs.queue_manage.infrastructure.repository.QueueRepository;
 import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
+import com.f4.fqs.queue_manage.presentation.request.UpdateExpirationTimeRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +16,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.List;
 
-import static com.f4.fqs.queue_manage.presentation.exception.QueueErrorCode.QUEUE_NAME_DUPLICATE;
+import static com.f4.fqs.queue_manage.presentation.exception.QueueErrorCode.*;
 
 @Slf4j
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class QueueService {
@@ -60,5 +66,38 @@ public class QueueService {
         } catch (Exception e) {
             throw new RuntimeException("Failed to save to Redis", e);
         }
+    }
+
+    public List<QueueInfo> getQueueInfoByUserId(Long userId) {
+        List<Queue> queues = queueRepository.findByUserId(userId);
+        return queues.stream()
+                .map(QueueInfo::fromQueue)
+                .toList();
+    }
+
+    @Transactional
+    public UpdateQueueExpirationTimeResponse updateExpirationTime(Long queueId, Long userId, UpdateExpirationTimeRequest request) {
+        Queue queue = this.validateQueueOwnership(queueId, userId);
+        queue.updateExpirationTime(request.expirationTime());
+        return new UpdateQueueExpirationTimeResponse(queue.getId(), queue.getExpirationTime());
+    }
+
+    @Transactional
+    public CloseQueueResponse closeQueue(Long queueId, Long userId) {
+        Queue queue = this.validateQueueOwnership(queueId, userId);
+        queue.closeQueue(false, LocalDateTime.now());
+        // TODO. 실제 서버 인스턴스 종료 로직
+        return new CloseQueueResponse(queue.getId(), queue.getExpirationTime());
+    }
+
+    private Queue validateQueueOwnership(Long queueId, Long userId) {
+        Queue queue = queueRepository.findById(queueId)
+                .orElseThrow(() -> new BusinessException(QUEUE_NOT_FOUND));
+
+        if (!queue.getUserId().equals(userId)) {
+            throw new BusinessException(QUEUE_USER_NOT_MATCHED);
+        }
+
+        return queue;
     }
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
@@ -1,0 +1,64 @@
+package com.f4.fqs.queue_manage.application.service;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.queue_manage.application.response.CreateQueueResponse;
+import com.f4.fqs.queue_manage.domain.model.Queue;
+import com.f4.fqs.queue_manage.infrastructure.repository.QueueRepository;
+import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static com.f4.fqs.queue_manage.presentation.exception.QueueErrorCode.QUEUE_NAME_DUPLICATE;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class QueueService {
+
+    private final QueueRepository queueRepository;
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Transactional
+    public CreateQueueResponse createQueue(CreateQueueRequest request, Long userId) {
+        String secretKey = this.generateRandomString();
+
+        if (queueRepository.existsByName(request.name())) {
+            throw new BusinessException(QUEUE_NAME_DUPLICATE);
+        }
+
+        // TODO. userId 존재 확인?
+
+        Queue queue = Queue.from(request, secretKey, userId);
+        Queue savedQueue = queueRepository.save(queue);
+
+        this.queueInfoSaveToRedis(secretKey, savedQueue);
+
+        // TODO. 개인별 인스턴스 생성 (비동기)
+
+        return new CreateQueueResponse(savedQueue.getId(), savedQueue.getSecretKey());
+    }
+
+    private String generateRandomString() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] randomBytes = new byte[16];
+        secureRandom.nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes).substring(0, 16);
+    }
+
+    private void queueInfoSaveToRedis(String secretKey, Queue queue) {
+        try {
+            String json = objectMapper.writeValueAsString(queue);
+            redisTemplate.opsForSet().add(secretKey, json); // 존재 확인 - redisTemplate.hasKey(secretKey)
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save to Redis", e);
+        }
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/BaseEntity.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/BaseEntity.java
@@ -26,8 +26,4 @@ public abstract class BaseEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/BaseEntity.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.f4.fqs.queue_manage.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/Queue.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/Queue.java
@@ -7,16 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "queues")
-@SQLDelete(sql = "UPDATE queues SET deleted_at = NOW() where id=?")
-@SQLRestriction(value = "deleted_at is NULL")
 public class Queue extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,17 +35,22 @@ public class Queue extends BaseEntity{
     private int maxMessageSize;
 
     @Column(nullable = false)
-    private int expirationTime;
+    private LocalDateTime expirationTime;
 
+    @Column(nullable = false)
     private boolean messageOrderGuaranteed;
 
+    @Column(nullable = false)
     private boolean messageDuplicationAllowed;
 
     @Column(nullable = false, unique = true)
     private String secretKey;
 
+    @Column(nullable = false)
+    private Boolean isActive;
+
     @Builder(access = AccessLevel.PROTECTED)
-    public Queue(int expirationTime, int maxMessageSize, boolean messageDuplicationAllowed, boolean messageOrderGuaranteed, int messageRetentionPeriod, String name, String secretKey, Long userId) {
+    public Queue(LocalDateTime expirationTime, int maxMessageSize, boolean messageDuplicationAllowed, boolean messageOrderGuaranteed, int messageRetentionPeriod, String name, String secretKey, Long userId) {
         this.expirationTime = expirationTime;
         this.maxMessageSize = maxMessageSize;
         this.messageDuplicationAllowed = messageDuplicationAllowed;
@@ -56,6 +59,7 @@ public class Queue extends BaseEntity{
         this.name = name;
         this.secretKey = secretKey;
         this.userId = userId;
+        this.isActive = true;
     }
 
     public static Queue from(CreateQueueRequest request, String secretKey, Long userId) {
@@ -69,5 +73,14 @@ public class Queue extends BaseEntity{
                 .secretKey(secretKey)
                 .userId(userId)
                 .build();
+    }
+
+    public void updateExpirationTime(LocalDateTime localDateTime) {
+        this.expirationTime = localDateTime;
+    }
+
+    public void closeQueue(boolean isActive, LocalDateTime now) {
+        this.isActive = isActive;
+        this.expirationTime = now;
     }
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/Queue.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/domain/model/Queue.java
@@ -1,0 +1,73 @@
+package com.f4.fqs.queue_manage.domain.model;
+
+import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Slf4j
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "queues")
+@SQLDelete(sql = "UPDATE queues SET deleted_at = NOW() where id=?")
+@SQLRestriction(value = "deleted_at is NULL")
+public class Queue extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "queue_id")
+    private Long Id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    // TODO. 아래 3개 필드의 단위를 어떻게 가져갈지?
+    @Column(nullable = false)
+    private int messageRetentionPeriod;
+
+    @Column(nullable = false)
+    private int maxMessageSize;
+
+    @Column(nullable = false)
+    private int expirationTime;
+
+    private boolean messageOrderGuaranteed;
+
+    private boolean messageDuplicationAllowed;
+
+    @Column(nullable = false, unique = true)
+    private String secretKey;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    public Queue(int expirationTime, int maxMessageSize, boolean messageDuplicationAllowed, boolean messageOrderGuaranteed, int messageRetentionPeriod, String name, String secretKey, Long userId) {
+        this.expirationTime = expirationTime;
+        this.maxMessageSize = maxMessageSize;
+        this.messageDuplicationAllowed = messageDuplicationAllowed;
+        this.messageOrderGuaranteed = messageOrderGuaranteed;
+        this.messageRetentionPeriod = messageRetentionPeriod;
+        this.name = name;
+        this.secretKey = secretKey;
+        this.userId = userId;
+    }
+
+    public static Queue from(CreateQueueRequest request, String secretKey, Long userId) {
+        return Queue.builder()
+                .expirationTime(request.expirationTime())
+                .maxMessageSize(request.maxMessageSize())
+                .messageDuplicationAllowed(request.messageDuplicationAllowed())
+                .messageOrderGuaranteed(request.messageOrderGuaranteed())
+                .messageRetentionPeriod(request.messageRetentionPeriod())
+                .name(request.name())
+                .secretKey(secretKey)
+                .userId(userId)
+                .build();
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/aop/AuthorizationAspect.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/aop/AuthorizationAspect.java
@@ -1,0 +1,43 @@
+package com.f4.fqs.queue_manage.infrastructure.aop;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import static com.f4.fqs.queue_manage.presentation.exception.QueueErrorCode.NOT_AUTHORIZATION;
+
+@Aspect
+@Component
+public class AuthorizationAspect {
+
+    @Around("@annotation(authorizationRequired) && args(.., httpRequest)")
+    public Object checkAuthorization(ProceedingJoinPoint joinPoint, AuthorizationRequired authorizationRequired, HttpServletRequest httpRequest) throws Throwable {
+        String rolesHeader = httpRequest.getHeader("X-User-Roles");
+
+        // 권한 검증 로직
+        if (!hasRequiredRole(rolesHeader, authorizationRequired.value())) {
+            throw new BusinessException(NOT_AUTHORIZATION);
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private boolean hasRequiredRole(String rolesHeader, String[] requiredRoles) {
+        if (rolesHeader == null || rolesHeader.isEmpty()) {
+            return false;
+        }
+
+        String[] userRoles = rolesHeader.split(","); // 역할이 여러 개일 경우 ,로 구분
+        for (String role : requiredRoles) {
+            for (String userRole : userRoles) {
+                if (userRole.trim().equals(role)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/aop/AuthorizationRequired.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/aop/AuthorizationRequired.java
@@ -1,0 +1,12 @@
+package com.f4.fqs.queue_manage.infrastructure.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthorizationRequired {
+    String[] value() default {};
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/config/JpaConfig.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.f4.fqs.queue_manage.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/config/RedisConfig.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.f4.fqs.queue_manage.infrastructure.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    RedisTemplate<String, Object> objectRedisTemplate(RedisConnectionFactory connectionFactory) {
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        var objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule())
+                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
+                .disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
+
+        var template = new RedisTemplate<String, Object>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
+    }
+
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/repository/QueueRepository.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/repository/QueueRepository.java
@@ -1,0 +1,10 @@
+package com.f4.fqs.queue_manage.infrastructure.repository;
+
+import com.f4.fqs.queue_manage.domain.model.Queue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QueueRepository extends JpaRepository<Queue, Long> {
+    boolean existsByName(String name);
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/repository/QueueRepository.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/infrastructure/repository/QueueRepository.java
@@ -5,6 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QueueRepository extends JpaRepository<Queue, Long> {
     boolean existsByName(String name);
+
+    List<Queue> findByUserId(Long userId);
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
@@ -1,0 +1,31 @@
+package com.f4.fqs.queue_manage.presentation.controller;
+
+import com.f4.fqs.commons.domain.response.ResponseBody;
+import com.f4.fqs.queue_manage.application.response.CreateQueueResponse;
+import com.f4.fqs.queue_manage.application.service.QueueService;
+import com.f4.fqs.queue_manage.infrastructure.aop.AuthorizationRequired;
+import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.f4.fqs.commons.domain.response.ResponseUtil.createSuccessResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/queue")
+public class QueueController {
+
+    private final QueueService queueService;
+
+    @AuthorizationRequired({"ROLE_ROOT"}) // TODO. ROOT 권한의 이름으로 대체
+    @PostMapping
+    public ResponseEntity<ResponseBody<CreateQueueResponse>> createQueue(
+            @RequestBody @Valid CreateQueueRequest request,
+            @RequestHeader("X-User-Id") Long userId,
+            HttpServletRequest httpRequest) {
+        return ResponseEntity.ok(createSuccessResponse(queueService.createQueue(request, userId)));
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
@@ -1,15 +1,21 @@
 package com.f4.fqs.queue_manage.presentation.controller;
 
 import com.f4.fqs.commons.domain.response.ResponseBody;
+import com.f4.fqs.queue_manage.application.response.CloseQueueResponse;
 import com.f4.fqs.queue_manage.application.response.CreateQueueResponse;
+import com.f4.fqs.queue_manage.application.response.UpdateQueueExpirationTimeResponse;
+import com.f4.fqs.queue_manage.application.service.QueueInfo;
 import com.f4.fqs.queue_manage.application.service.QueueService;
 import com.f4.fqs.queue_manage.infrastructure.aop.AuthorizationRequired;
 import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
+import com.f4.fqs.queue_manage.presentation.request.UpdateExpirationTimeRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.f4.fqs.commons.domain.response.ResponseUtil.createSuccessResponse;
 
@@ -26,6 +32,36 @@ public class QueueController {
             @RequestBody @Valid CreateQueueRequest request,
             @RequestHeader("X-User-Id") Long userId,
             HttpServletRequest httpRequest) {
+
         return ResponseEntity.ok(createSuccessResponse(queueService.createQueue(request, userId)));
+    }
+
+    @AuthorizationRequired({"ROLE_ROOT"})
+    @GetMapping
+    public ResponseEntity<ResponseBody<List<QueueInfo>>> getQueueInfoByUserId(
+            @RequestHeader("X-User-Id") Long userId,
+            HttpServletRequest httpRequest) {
+
+        return ResponseEntity.ok(createSuccessResponse(queueService.getQueueInfoByUserId(userId)));
+    }
+
+    @AuthorizationRequired({"ROLE_ROOT"})
+    @PatchMapping("/{queueId}/expiration-time")
+    public ResponseEntity<ResponseBody<UpdateQueueExpirationTimeResponse>> updateExpirationTime(
+            @PathVariable Long queueId,
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody @Valid UpdateExpirationTimeRequest request,
+            HttpServletRequest httpRequest) {
+
+        return ResponseEntity.ok(createSuccessResponse(queueService.updateExpirationTime(queueId, userId, request)));
+    }
+
+    @AuthorizationRequired({"ROLE_ROOT"})
+    @PatchMapping("/{queueId}/close")
+    public ResponseEntity<ResponseBody<CloseQueueResponse>> closeQueue(
+            @PathVariable Long queueId,
+            @RequestHeader("X-User-Id") Long userId) {
+
+        return ResponseEntity.ok(createSuccessResponse(queueService.closeQueue(queueId, userId)));
     }
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/GlobalExceptionHandler.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/GlobalExceptionHandler.java
@@ -31,6 +31,13 @@ public class GlobalExceptionHandler {
                 .body(new FailedResponseBody(QueueErrorCode.INVALID_INPUT_VALUE.getCode(), errorMessage));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class) // IllegalArgumentException
+    public ResponseEntity<ResponseBody<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException : {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(new FailedResponseBody(QueueErrorCode.INVALID_INPUT_VALUE.getCode(), e.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseBody<Void>> handleException(Exception e) {
         log.error("Exception : {}", e.getMessage());

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/GlobalExceptionHandler.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.f4.fqs.queue_manage.presentation.exception;
+
+import com.f4.fqs.commons.domain.exception.BusinessException;
+import com.f4.fqs.commons.domain.exception.ErrorCode;
+import com.f4.fqs.commons.domain.response.FailedResponseBody;
+import com.f4.fqs.commons.domain.response.ResponseBody;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class) // custom 에러
+    public ResponseEntity<ResponseBody<Void>> handleServiceException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(new FailedResponseBody(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) // Valid
+    public ResponseEntity<ResponseBody<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        log.error("MethodArgumentNotValidException : {}", errorMessage);
+        return ResponseEntity.badRequest()
+                .body(new FailedResponseBody(QueueErrorCode.INVALID_INPUT_VALUE.getCode(), errorMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseBody<Void>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage());
+        return ResponseEntity.internalServerError()
+                .body(new FailedResponseBody(
+                        QueueErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                        QueueErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/QueueErrorCode.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/QueueErrorCode.java
@@ -1,0 +1,25 @@
+package com.f4.fqs.queue_manage.presentation.exception;
+
+import com.f4.fqs.commons.domain.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QueueErrorCode implements ErrorCode {
+    // Common
+    INVALID_INPUT_VALUE(400, "COMMON_0001", "잘못된 입력 값입니다."),
+    INTERNAL_SERVER_ERROR(500, "COMMON_002", "서버 에러입니다."),
+
+    // Security
+    NOT_AUTHORIZATION(403, "SECURITY_001", "권한이 없습니다."),
+
+    // Queue
+    QUEUE_NAME_DUPLICATE(409, "QUEUE_001", "이미 존재하는 대기열 이름입니다."),
+    
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/QueueErrorCode.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/exception/QueueErrorCode.java
@@ -16,6 +16,8 @@ public enum QueueErrorCode implements ErrorCode {
 
     // Queue
     QUEUE_NAME_DUPLICATE(409, "QUEUE_001", "이미 존재하는 대기열 이름입니다."),
+    QUEUE_NOT_FOUND(404, "QUEUE_002", "존재하지 않는 대기열입니다."),
+    QUEUE_USER_NOT_MATCHED(403, "QUEUE_003", "해당 대기열의 root 사용자가 아닙니다."),
     
     ;
 

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/CreateQueueRequest.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/CreateQueueRequest.java
@@ -1,0 +1,16 @@
+package com.f4.fqs.queue_manage.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateQueueRequest(
+        @NotBlank @Size(max = 16)
+        String name,
+        @NotNull int messageRetentionPeriod,
+        @NotNull int maxMessageSize,
+        @NotNull int expirationTime,
+        @NotNull boolean messageOrderGuaranteed,
+        @NotNull boolean messageDuplicationAllowed
+) {
+}

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/CreateQueueRequest.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/CreateQueueRequest.java
@@ -1,15 +1,18 @@
 package com.f4.fqs.queue_manage.presentation.request;
 
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
 
 public record CreateQueueRequest(
         @NotBlank @Size(max = 16)
         String name,
         @NotNull int messageRetentionPeriod,
         @NotNull int maxMessageSize,
-        @NotNull int expirationTime,
+        @NotNull @Future LocalDateTime expirationTime,
         @NotNull boolean messageOrderGuaranteed,
         @NotNull boolean messageDuplicationAllowed
 ) {

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/UpdateExpirationTimeRequest.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/request/UpdateExpirationTimeRequest.java
@@ -1,0 +1,11 @@
+package com.f4.fqs.queue_manage.presentation.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record UpdateExpirationTimeRequest(
+        @NotNull @Future LocalDateTime expirationTime
+) {
+}

--- a/service/queue_manage/src/main/resources/application.yml
+++ b/service/queue_manage/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+server:
+  port: 19095
+
+spring:
+  application:
+    name: queue-manage-service
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/queue
+    username: root
+    password: password
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        hbm2ddl.auto: update
+        default_batch_fetch_size: 100
+    open-in-view: false
+    show-sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/

--- a/service/queue_manage/src/test/java/com/f4/fqs/queue_manage/QueueManageApplicationTests.java
+++ b/service/queue_manage/src/test/java/com/f4/fqs/queue_manage/QueueManageApplicationTests.java
@@ -1,0 +1,13 @@
+package com.f4.fqs.queue_manage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class QueueManageApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,6 @@ include 'service:gateway'
 include 'service:auth'
 include 'service:user'
 include 'service:queue'
+include 'service:queue_manage'
 
 include 'common:domain'


### PR DESCRIPTION
<!-- 제목의 양식은 '[#이슈번호] 설명' 으로 구성해주세요. -->

### 👀 관련 이슈
- closed: #21 

### ✨ 작업한 내용
- Queue Server 기본 CRUD 기능 구현

### 🌀 PR Point
- 기존 web flux 로 구성된 코드에서 가져와서 mvc로 재구성 한 후, CRUD 기능 초기 개발을 했습니다.
- kafka to redis 정책 변경을 통해 순서 보장, 중복 여/부 필드의 의미가 퇴색되긴 했지만, 일단 넣어놨습니다.

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|대기열 생성|<img width="631" alt="image" src="https://github.com/user-attachments/assets/9d33cc8a-3d8d-4d50-9511-4763cd94e03c">|
|root id 기준 대기열 목록|<img width="515" alt="image" src="https://github.com/user-attachments/assets/98b05f14-f44a-4198-9320-663bb3fee63a">|
|대기열 종료시간 수정|<img width="469" alt="image" src="https://github.com/user-attachments/assets/097d8173-d42c-41ae-a35c-5203198367c0">|
|대기열 닫기|<img width="552" alt="image" src="https://github.com/user-attachments/assets/9e2a077a-de73-4f7a-897d-bc75e7d3fd8d">|
|db 저장 확인|<img width="1175" alt="image" src="https://github.com/user-attachments/assets/4b742f1a-c6e1-4623-8255-453532f1114a">|

