### PR TITLE
feat : refector/52-authorization-separate-jwt-and-secretKey and add throw…

### DIFF
--- a/service/gateway/gateway_server/src/main/java/com/f4/fqs/gateway/config/SecurityConfig.java
+++ b/service/gateway/gateway_server/src/main/java/com/f4/fqs/gateway/config/SecurityConfig.java
@@ -100,22 +100,11 @@ public class SecurityConfig {
                     log.info("Decoded secret key bytes length: {}", bytes.length); // 로그 추가
 
                     Claims claims = Jwts
-                            .parser()
-                            .setSigningKey(secretKey)
-                            .build()
-                            .parseClaimsJws(token)
-                            .getBody();
-
-                    log.info("Claims: {}", claims); // 로그 추가
-
-                    /*
-                        // JWT 토큰 만료 검증
-                        if (claims.getExpiration().before(new Date())) {
-                            log.error("JWT token has expired");
-                            exchange.getResponse().setStatusCode(HttpStatusCode.valueOf(401));
-
-                            return exchange.getResponse().setComplete();
-                    }*/
+                                .parser()
+                                .setSigningKey(secretKey)
+                                .build()
+                                .parseClaimsJws(token)
+                                .getBody();
 
                     Long userId = Long.valueOf(claims.get("id").toString());
                     String role = claims.get("role").toString();
@@ -147,8 +136,12 @@ public class SecurityConfig {
 
                     return chain.filter(modifiedExchange);
 
-                } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+                } catch (io.jsonwebtoken.JwtException  e) {
                     log.error("JWT validation error: {}", e.getMessage(), e); // 로그 추가
+
+                    exchange.getResponse().setStatusCode(HttpStatusCode.valueOf(401));
+                    return exchange.getResponse().setComplete();
+
                 }
             }
 


### PR DESCRIPTION
… error code logic

<!-- 제목의 양식은 '[#이슈번호] 설명' 으로 구성해주세요. -->

### 👀 관련 이슈
- closed: #52 

### ✨ 작업한 내용
1. jwt , secretKey 검증 로직 분리
2. gateway 에서 각 상황 발생 시 일치하는 에러 발생 로직 추가

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||


