### PR TITLE
feat : secret key 와 queue 이름의 쌍이 맞는지 검사하는 api 구현

### DIFF
--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/application/service/QueueService.java
@@ -11,7 +11,6 @@ import com.f4.fqs.queue_manage.infrastructure.docker.DockerService;
 import com.f4.fqs.queue_manage.infrastructure.repository.QueueRepository;
 import com.f4.fqs.queue_manage.presentation.request.CreateQueueRequest;
 import com.f4.fqs.queue_manage.presentation.request.UpdateExpirationTimeRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,7 +35,6 @@ import static com.f4.fqs.queue_manage.presentation.exception.QueueErrorCode.*;
 public class QueueService {
 
     private final QueueRepository queueRepository;
-    private final ObjectMapper objectMapper;
     private final RedisTemplate<String, Object> redisTemplate;
     private final RedisTemplate<String, ApiRoute> redisRouteTemplate;
     private final DockerService dockerService;
@@ -79,16 +77,7 @@ public class QueueService {
     }
 
     private void saveQueueInfoToRedis(String secretKey, Queue queue) {
-        String json = serializeQueueToJson(queue);
-        redisTemplate.opsForSet().add(secretKey, json);
-    }
-
-    private String serializeQueueToJson(Object obj) {
-        try {
-            return objectMapper.writeValueAsString(obj);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialize queue to JSON", e);
-        }
+        redisTemplate.opsForSet().add(secretKey, queue.getName());
     }
 
     private void addApiRoute(Queue savedQueue) {
@@ -169,4 +158,7 @@ public class QueueService {
         }
     }
 
+    public Boolean validateSecretKeyAndQueueName(String secretKey, String queueName) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(secretKey, queueName));
+    }
 }

--- a/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
+++ b/service/queue_manage/src/main/java/com/f4/fqs/queue_manage/presentation/controller/QueueController.java
@@ -69,4 +69,11 @@ public class QueueController {
 
         return ResponseEntity.ok(createSuccessResponse(queueService.closeQueue(queueId, userId)));
     }
+
+    @GetMapping("/validate")
+    public ResponseEntity<Boolean> validateSecretKeyAndQueueName(
+            @RequestHeader("X-Secret-Key") String secretKey,
+            @RequestParam String queueName) {
+        return ResponseEntity.ok(queueService.validateSecretKeyAndQueueName(secretKey, queueName));
+    }
 }


### PR DESCRIPTION
<!-- 제목의 양식은 '[#이슈번호] 설명' 으로 구성해주세요. -->

### 👀 관련 이슈
- closed: #59 <!--연관된 이슈를 작성하면 자동으로 닫힙니다.-->

### ✨ 작업한 내용
- 기존 secret key 를 가지고 endpoint를 가져오기로 한 기획에 문제점이 이미 사용자는 secret key와 queue name을 가지고 있다는 것이였습니다.
- 어저피 endpoint url 도 queue name 기반으로 라우팅되기에 secret key와 queue name만 검증하는 과정으로 진행했습니다.
- 결과는 true or false로 구분하기 쉽게 반환했습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|기능 동작|![image](https://github.com/user-attachments/assets/947be745-beaa-4340-8190-fd59be3d9f6c)|


